### PR TITLE
Removed CSS style clash with Tailwind in stepper.svelte

### DIFF
--- a/src/lib/stepper.svelte
+++ b/src/lib/stepper.svelte
@@ -238,7 +238,7 @@
 </script>
 
 <div
-  class="container"
+  class="stepper-container"
   style:height={`${$containerHeight}px`}
   style:overflow={transitioning ? 'hidden' : 'visible'}
 >
@@ -267,7 +267,7 @@
 </div>
 
 <style>
-  .container {
+  .stepper-container {
     position: relative;
   }
 


### PR DESCRIPTION
Fixed issue #10 by renamed .container to .stepper-container in the containing element and styles.